### PR TITLE
Update access token schema to include subject and client ID properties

### DIFF
--- a/src/schemas/access-token.yaml
+++ b/src/schemas/access-token.yaml
@@ -3,23 +3,29 @@ $schema: "http://json-schema.org/draft-07/schema#"
 access_token:
   type: object
   properties:
-    jti:
-      type: string
-      description: "The JWT ID."
     iss:
       type: string
       description: "The issuer of the token."
     exp:
       type: integer
       description: "Expiration time of the token as a Unix timestamp."
-    iat:
-      type: integer
-      description: "Issued at time of the token as a Unix timestamp."
     aud:
       type: array
       items:
         type: string
       description: "The intended recipients (audiences) of the token."
+    sub:
+      type: string
+      description: "The subject of the token."
+    client_id:
+      type: string
+      description: "The client identifier of the OAuth 2.0 client that requested the token."
+    iat:
+      type: integer
+      description: "Issued at time of the token as a Unix timestamp."
+    jti:
+      type: string
+      description: "The JWT ID."
     scope:
       type: string
       description: "The permissions that this token grants."
@@ -33,10 +39,11 @@ access_token:
       required:
         - jkt
   required:
-    - jti
     - iss
     - exp
-    - iat
     - aud
-    - scope
+    - sub
+    - client_id
+    - iat
+    - jti
     - cnf


### PR DESCRIPTION
This pull request includes updates to the `src/schemas/access-token.yaml` file to improve the structure and completeness of the access token schema. The most important changes include the addition of new properties, reordering of existing properties, and updating the required fields.

Changes to the access token schema:

* Added new properties `sub` and `client_id` to the access token schema. (`[src/schemas/access-token.yamlL6-R28](diffhunk://#diff-ce79857cb86a8a6d760aa22005d56e333302e192ecd7ae1fd7d17c5571fc200bL6-R28)`)
* Reordered properties to improve readability and consistency, including moving `iat` and `jti`. (`[src/schemas/access-token.yamlL6-R28](diffhunk://#diff-ce79857cb86a8a6d760aa22005d56e333302e192ecd7ae1fd7d17c5571fc200bL6-R28)`)
* Updated the list of required fields to include `sub` and `client_id`, and to reflect the reordering of properties. (`[src/schemas/access-token.yamlL36-R48](diffhunk://#diff-ce79857cb86a8a6d760aa22005d56e333302e192ecd7ae1fd7d17c5571fc200bL36-R48)`)