### PR TITLE
Exclude IntelliJ and Poetry files from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .vscode
 *.log
 *.tar.gz
@@ -5,3 +6,5 @@
 __pycache__/
 var/
 console
+poetry.lock
+dist/


### PR DESCRIPTION
This pull request updates the `.gitignore` file to exclude files and directories associated with IntelliJ IDEA and Python Poetry. These files are typically environment-specific and should not be tracked in version control.