### PR TITLE
Develop

### DIFF
--- a/components/ZETA-Guard/kind-config-zeta-guard.yaml
+++ b/components/ZETA-Guard/kind-config-zeta-guard.yaml
@@ -7,12 +7,6 @@ nodes:
 - role: worker
 - role: worker
 - role: worker
-- role: worker
-- role: worker
-- role: worker
-- role: worker
-- role: worker
-- role: worker
   extraPortMappings:
   - containerPort: 80
     hostPort: 80   # Ingress-Port

--- a/components/ZETA-Guard/resource-server/src/Dockerfile
+++ b/components/ZETA-Guard/resource-server/src/Dockerfile
@@ -9,6 +9,9 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 
+# Ensure go.sum is tidy and up-to-date
+RUN go mod tidy
+
 # Copy the source code
 COPY . .
 

--- a/components/ZETA-Guard/resource-server/src/go.mod
+++ b/components/ZETA-Guard/resource-server/src/go.mod
@@ -4,6 +4,7 @@ go 1.23.6
 
 require (
 	go.opentelemetry.io/otel v1.34.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.34.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0
 	go.opentelemetry.io/otel/metric v1.34.0
 	go.opentelemetry.io/otel/sdk v1.34.0
@@ -18,12 +19,11 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.34.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	golang.org/x/net v0.36.0 // indirect
-	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/text v0.21.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/text v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
 	google.golang.org/grpc v1.69.4 // indirect

--- a/components/ZETA-Guard/resource-server/src/go.mod
+++ b/components/ZETA-Guard/resource-server/src/go.mod
@@ -21,7 +21,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.34.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
-	golang.org/x/net v0.34.0 // indirect
+	golang.org/x/net v0.36.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f // indirect

--- a/components/ZETA-Guard/resource-server/src/go.sum
+++ b/components/ZETA-Guard/resource-server/src/go.sum
@@ -33,8 +33,6 @@ go.opentelemetry.io/otel/metric v1.34.0 h1:+eTR3U0MyfWjRDhmFMxe2SsW64QrZ84AOhvqS
 go.opentelemetry.io/otel/metric v1.34.0/go.mod h1:CEDrp0fy2D0MvkXE+dPV7cMi8tWZwX3dmaIhwPOaqHE=
 go.opentelemetry.io/otel/sdk v1.34.0 h1:95zS4k/2GOy069d321O8jWgYsW3MzVV+KuSPKp7Wr1A=
 go.opentelemetry.io/otel/sdk v1.34.0/go.mod h1:0e/pNiaMAqaykJGKbi+tSjWfNNHMTxoC9qANsCzbyxU=
-go.opentelemetry.io/otel/sdk/metric v1.31.0 h1:i9hxxLJF/9kkvfHppyLL55aW7iIJz4JjxTeYusH7zMc=
-go.opentelemetry.io/otel/sdk/metric v1.31.0/go.mod h1:CRInTMVvNhUKgSAMbKyTMxqOBC0zgyxzW55lZzX43Y8=
 go.opentelemetry.io/otel/sdk/metric v1.34.0 h1:5CeK9ujjbFVL5c1PhLuStg1wxA7vQv7ce1EK0Gyvahk=
 go.opentelemetry.io/otel/sdk/metric v1.34.0/go.mod h1:jQ/r8Ze28zRKoNRdkjCZxfs6YvBTG1+YIqyFVFYec5w=
 go.opentelemetry.io/otel/trace v1.34.0 h1:+ouXS2V8Rd4hp4580a8q23bg0azF2nI8cqLYnC8mh/k=
@@ -43,12 +41,12 @@ go.opentelemetry.io/proto/otlp v1.5.0 h1:xJvq7gMzB31/d406fB8U5CBdyQGw4P399D1aQWU
 go.opentelemetry.io/proto/otlp v1.5.0/go.mod h1:keN8WnHxOy8PG0rQZjJJ5A2ebUoafqWp0eVQ4yIXvJ4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
-golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
-golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
-golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
-golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+golang.org/x/net v0.36.0 h1:vWF2fRbw4qslQsQzgFqZff+BItCvGFQqKzKIzx1rmoA=
+golang.org/x/net v0.36.0/go.mod h1:bFmbeoIPfrw4sMHNhb4J9f6+tPziuGjq7Jk/38fxi1I=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
+golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
 google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f h1:gap6+3Gk41EItBuyi4XX/bp4oqJ3UwuIMl25yGinuAA=
 google.golang.org/genproto/googleapis/api v0.0.0-20250115164207-1a7da9e5054f/go.mod h1:Ic02D47M+zbarjYYUlK57y316f2MoN0gjAwI3f2S95o=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f h1:OxYkA3wjPsZyBylwymxSHa7ViiW1Sml4ToBrncvFehI=

--- a/components/ZETA-Guard/setup.sh
+++ b/components/ZETA-Guard/setup.sh
@@ -122,7 +122,7 @@ fi
 
 # Erstellen des Docker-Images für den Resource Server
 echo "📦 Erstelle das Docker-Image ${DOCKER_IMAGE} aus ${DOCKERFILE_PATH}..."
-docker build -t "${DOCKER_IMAGE}" -f "${DOCKERFILE_PATH}" resource-server/src
+docker build --no-cache -t "${DOCKER_IMAGE}" -f "${DOCKERFILE_PATH}" resource-server/src
 
 # Prüfen, ob der Kind-Cluster existiert
 if kind get clusters | grep -q "^${CLUSTER_NAME}$"; then


### PR DESCRIPTION
This pull request includes several changes to the `components/ZETA-Guard` directory to update dependencies, improve Dockerfile practices, and modify Kubernetes configuration. The most important changes include updating the Go module dependencies, ensuring the Go module file is tidy, and modifying the Docker build process to not use the cache.

Dependency updates:

* [`components/ZETA-Guard/resource-server/src/go.mod`](diffhunk://#diff-31242c39509ae68a8fa413c336944acddc905648e78a91b3fb0e4517cca92043R7): Added `go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc` dependency and updated indirect dependencies for `golang.org/x/net`, `golang.org/x/sys`, and `golang.org/x/text`. [[1]](diffhunk://#diff-31242c39509ae68a8fa413c336944acddc905648e78a91b3fb0e4517cca92043R7) [[2]](diffhunk://#diff-31242c39509ae68a8fa413c336944acddc905648e78a91b3fb0e4517cca92043L21-R26)

Dockerfile improvements:

* [`components/ZETA-Guard/resource-server/src/Dockerfile`](diffhunk://#diff-d4e876de56517d13e016589b0cd619eac0c99df19fc2f3dfa235cdade2e8668dR12-R14): Added a step to ensure `go.sum` is tidy and up-to-date.
* [`components/ZETA-Guard/setup.sh`](diffhunk://#diff-b776274a07589e753588c3b9f0f7c6804478b53c15717804cd101e52332259cfL125-R125): Modified the Docker build command to use the `--no-cache` option to ensure a fresh build.

Kubernetes configuration changes:

* [`components/ZETA-Guard/kind-config-zeta-guard.yaml`](diffhunk://#diff-506c574a7dc34f730fe005ce189e68362480ca26ed37c22bd6ae9efa627dd7c1L9-L14): Removed multiple worker node entries from the Kubernetes configuration.