### PR TITLE
Capitalize the JSON abbreviation consistently

### DIFF
--- a/src/schemas/access-token.yaml
+++ b/src/schemas/access-token.yaml
@@ -1,4 +1,4 @@
-# Schema for the AccessToken json object. Issuer is a PDP authorization server.
+# Schema for the AccessToken JSON object. Issuer is a PDP authorization server.
 $schema: "http://json-schema.org/draft-07/schema#"
 access_token:
   type: object

--- a/src/schemas/as-well-known.yaml
+++ b/src/schemas/as-well-known.yaml
@@ -1,4 +1,4 @@
-# Schema for the PEP authorization server .well-known json object
+# Schema for the PEP authorization server .well-known JSON object
 $schema: "http://json-schema.org/draft-07/schema#"
 type: object
 properties:

--- a/src/schemas/opr-well-known.yaml
+++ b/src/schemas/opr-well-known.yaml
@@ -1,4 +1,4 @@
-# Schema for the OAuth protected resource server .well-known json object
+# Schema for the OAuth protected resource server .well-known JSON object
 $schema: "http://json-schema.org/draft-07/schema#"
 type: object
 properties:

--- a/src/schemas/popp-token.yaml
+++ b/src/schemas/popp-token.yaml
@@ -1,4 +1,4 @@
-# Schema for the ProofOfPatientPresenceToken json object. Issuer is a PoPP server.
+# Schema for the ProofOfPatientPresenceToken JSON object. Issuer is a PoPP server.
 $schema: "http://json-schema.org/draft-07/schema#"
 proof_of_patient_presence_token:
   type: object

--- a/src/schemas/session.yaml
+++ b/src/schemas/session.yaml
@@ -1,4 +1,4 @@
-# Schema for the user-session json object.
+# Schema for the user-session JSON object.
 # The PDP authorization server stores the state of the user-session for
 # authenticated user.
 user_session:

--- a/src/schemas/user-info.yaml
+++ b/src/schemas/user-info.yaml
@@ -1,6 +1,5 @@
-# Schema for the user-info json object.
-# The PDP authorization server stores user-info records for all authenticated
-# user. 
+# Schema for the user-info JSON object.
+# The PDP authorization server stores user-info records for all authenticated users.
 # The PEP can request user-info records for a user by sending a request.
 #
 $schema: "http://json-schema.org/draft-07/schema#"


### PR DESCRIPTION
It is a well-established term and always spelled in all-caps.